### PR TITLE
워크스페이스 페이지에서 주문 조회 페이지로 연결하는 버튼 추가

### DIFF
--- a/src/hook/useCustomNavigate.tsx
+++ b/src/hook/useCustomNavigate.tsx
@@ -1,0 +1,14 @@
+import { useLocation, useNavigate } from 'react-router-dom';
+
+function useCustomNavigate() {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  const appendPath = (path: string) => {
+    navigate(location.pathname + path);
+  };
+
+  return { appendPath };
+}
+
+export default useCustomNavigate;

--- a/src/page/Admin/AdminWorkspace.tsx
+++ b/src/page/Admin/AdminWorkspace.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 import { useParams } from 'react-router-dom';
+import useCustomNavigate from '../../hook/useCustomNavigate';
 
 function AdminWorkspace() {
   const { workspaceId } = useParams<{ workspaceId: string }>();
+  const { appendPath } = useCustomNavigate();
 
   return (
     <div>
       <div>workspaceId: {workspaceId}</div>
+      <button type={'button'} onClick={() => appendPath('/orders')}>
+        주문 조회
+      </button>
     </div>
   );
 }


### PR DESCRIPTION
## 📚 개요

워크스페이스 페이지에서 주문 조회 페이지로 연결하는 버튼 추가했습니다.
현재 location에서 path만 붙여주면 되는 부분인데 다른 곳에서도 사용할 것 같아서 hook으로 만들었습니다.

## 🕐 리뷰 예상 시간

> 3m

## ❗❗ 중요한 변경점(Option)

![image](https://github.com/Ji-InPark/KioSchool/assets/81283634/22b3a2b3-fa77-4d95-9aa4-af48c841cc18)
