### PR TITLE
어드민 홈페이지에서 접근가능한 워크스페이스 보여주기

### DIFF
--- a/src/hook/useUser.tsx
+++ b/src/hook/useUser.tsx
@@ -1,14 +1,24 @@
 import useApi from './useApi';
+import { Workspace } from '../type';
+import { useSetRecoilState } from 'recoil';
+import { workspacesAtom } from '../recoil/atoms';
 
 function useUser() {
   const { adminApi } = useApi();
+  const setWorkspaces = useSetRecoilState(workspacesAtom);
 
   const isLoggedIn = () => {
     adminApi.get('/user');
     return true;
   };
 
-  return { isLoggedIn };
+  const fetchWorkspaces = () => {
+    adminApi.get<Workspace[]>('/workspaces').then((res) => {
+      setWorkspaces(res.data);
+    });
+  };
+
+  return { isLoggedIn, fetchWorkspaces };
 }
 
 export default useUser;

--- a/src/page/Admin/AdminHome.tsx
+++ b/src/page/Admin/AdminHome.tsx
@@ -1,13 +1,37 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import useUser from '../../hook/useUser';
+import { useRecoilValue } from 'recoil';
+import { workspacesAtom } from '../../recoil/atoms';
+import useCustomNavigate from '../../hook/useCustomNavigate';
 
 function AdminHome() {
-  const { isLoggedIn } = useUser();
+  const { fetchWorkspaces } = useUser();
+  const { appendPath } = useCustomNavigate();
+  const workspaces = useRecoilValue(workspacesAtom);
+
+  useEffect(() => {
+    fetchWorkspaces();
+  }, []);
+
+  if (workspaces?.length === 0) {
+    return <div>워크스페이스가 없습니다.</div>;
+  }
 
   return (
     <div>
-      <div>AdminHome 여기가 헤더가 되어야 할듯?</div>
-      isLoggedIn: {isLoggedIn() ? 'true' : 'false'}
+      {workspaces.map((it) => (
+        <div key={it.id}>
+          {it.id} - {it.name}
+          <button
+            type={'button'}
+            onClick={() => {
+              appendPath(`/workspace/${it.id}`);
+            }}
+          >
+            이동
+          </button>
+        </div>
+      ))}
     </div>
   );
 }

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -1,7 +1,12 @@
 import { atom } from 'recoil';
-import { Order } from '../type';
+import { Order, Workspace } from '../type';
 
 export const ordersAtom = atom<Order[]>({
   key: 'ordersAtom',
+  default: [],
+});
+
+export const workspacesAtom = atom<Workspace[]>({
+  key: 'workspacesAtom',
   default: [],
 });


### PR DESCRIPTION
## 📚 개요

어드민 홈페이지에서 접근가능한 워크스페이스 보여주게 구현했습니다.
또한 해당 워크스페이스 페이지로 넘어갈 수 있게 버튼도 붙여놨습니다.

이 후에 해당 워크스페이스에 상품을 조회하고 추가 및 수정할 수 있는 페이지를 구현할 예정입니다.

## 🕐 리뷰 예상 시간

> 3m

## ❗❗ 중요한 변경점(Option)

<img width="792" alt="image" src="https://github.com/Ji-InPark/KioSchool/assets/81283634/d394497d-1817-4bfd-a560-01fe5126810d">
