### PR TITLE
ADD - 주문페이지에 모달창 추가 및 주문 버튼 생성

### DIFF
--- a/src/component/common/button/AppButton.tsx
+++ b/src/component/common/button/AppButton.tsx
@@ -7,7 +7,7 @@ export interface AppButtonProps extends React.ButtonHTMLAttributes<HTMLButtonEle
 
 const sizeMap = {
   small: '120px',
-  medium: '155px',
+  medium: '270px',
   large: '500px',
 };
 

--- a/src/component/product/ProductCard.tsx
+++ b/src/component/product/ProductCard.tsx
@@ -1,6 +1,8 @@
 import { Product } from '../../type';
 import styled from '@emotion/styled';
 import AppLabel from '../common/label/AppLabel';
+import React, { useState } from 'react';
+import ProductDialog from './ProductDialog';
 
 interface ProductCardProps {
   product: Product;
@@ -24,23 +26,28 @@ const LabelContainer = styled.div`
 const ImageContainer = styled.div``;
 
 function ProductCard({ product }: ProductCardProps) {
+  const [openDialog, setOpenDialog] = useState<boolean>(false);
+
   if (!product) return <div></div>;
 
   return (
-    <Container>
-      <LabelContainer>
-        <AppLabel size={'medium'}>{product.name}</AppLabel>
-        <AppLabel size={'small'}>{product.description}</AppLabel>
-        <AppLabel size={'small'}>{product.price}원</AppLabel>
-      </LabelContainer>
-      <ImageContainer>
-        <img
-          src={product.imageUrl}
-          alt={product.name}
-          style={{ float: 'right', maxWidth: '140px', maxHeight: '140px', objectFit: 'cover', border: 'none', borderRadius: '10px' }}
-        />
-      </ImageContainer>
-    </Container>
+    <>
+      {openDialog && <ProductDialog product={product} closeDialog={() => setOpenDialog(false)} />}
+      <Container onClick={() => setOpenDialog(true)}>
+        <LabelContainer>
+          <AppLabel size={'medium'}>{product.name}</AppLabel>
+          <AppLabel size={'small'}>{product.description}</AppLabel>
+          <AppLabel size={'small'}>{product.price}원</AppLabel>
+        </LabelContainer>
+        <ImageContainer>
+          <img
+            src={product.imageUrl}
+            alt={product.name}
+            style={{ float: 'right', maxWidth: '140px', maxHeight: '140px', objectFit: 'cover', border: 'none', borderRadius: '10px' }}
+          />
+        </ImageContainer>
+      </Container>
+    </>
   );
 }
 

--- a/src/component/product/ProductDialog.tsx
+++ b/src/component/product/ProductDialog.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+import { Product } from '../../type';
+import styled from '@emotion/styled';
+import AppLabel from '../common/label/AppLabel';
+import AppButton from '../common/button/AppButton';
+import { useSetRecoilState } from 'recoil';
+import { orderBasketAtom } from '../../recoil/atoms';
+
+interface ProductDialogProps {
+  product: Product;
+  closeDialog: () => void;
+}
+
+const Container = styled.div`
+  z-index: 1000;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(238, 238, 238, 0.8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const ModalContainer = styled.div`
+  width: 100%;
+  height: 80%;
+  padding: 15px;
+  background: white;
+  border-radius: 20px;
+  display: flex;
+  flex-direction: column;
+`;
+
+const ProductImage = styled.img`
+  padding: 20px;
+  object-fit: contain;
+  border-radius: 10px;
+`;
+
+const CounterContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+`;
+
+const CounterButtonContainer = styled.div`
+  display: flex;
+`;
+
+const OrderButtonContainer = styled.div`
+  margin-top: auto;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+function ProductDialog(props: ProductDialogProps) {
+  const [count, setCount] = useState<number>(1);
+  const setOrderBasket = useSetRecoilState(orderBasketAtom);
+
+  const addOrderBasket = () => {
+    const orderBasket = {
+      productId: props.product.id,
+      quantity: count,
+    };
+    setOrderBasket((prevState) => {
+      const index = prevState.findIndex((it) => it.productId === orderBasket.productId);
+      if (index === -1) return [...prevState, orderBasket];
+
+      return prevState.map((it) => {
+        if (it.productId === orderBasket.productId) return { ...it, quantity: it.quantity + orderBasket.quantity };
+
+        return it;
+      });
+    });
+    props.closeDialog();
+  };
+
+  return (
+    <Container>
+      <ModalContainer>
+        <ProductImage src={props.product.imageUrl} />
+        <AppLabel size={'large'}>{props.product.name}</AppLabel>
+        <AppLabel size={'medium'}>{props.product.description}</AppLabel>
+        <CounterContainer>
+          <AppLabel size={'medium'}>수량</AppLabel>
+          <CounterButtonContainer>
+            <button disabled={count == 1} onClick={() => setCount((prevState) => prevState - 1)}>
+              -
+            </button>
+            <AppLabel size={'medium'}>{count}개</AppLabel>
+            <button onClick={() => setCount((prevState) => prevState + 1)}>+</button>
+          </CounterButtonContainer>
+        </CounterContainer>
+        <OrderButtonContainer>
+          <AppButton size={'medium'} onClick={addOrderBasket}>
+            {props.product.price * count}원 담기
+          </AppButton>
+        </OrderButtonContainer>
+      </ModalContainer>
+    </Container>
+  );
+}
+
+export default ProductDialog;

--- a/src/component/product/ProductDialog.tsx
+++ b/src/component/product/ProductDialog.tsx
@@ -5,6 +5,7 @@ import AppLabel from '../common/label/AppLabel';
 import AppButton from '../common/button/AppButton';
 import { useSetRecoilState } from 'recoil';
 import { orderBasketAtom } from '../../recoil/atoms';
+import CloseSvg from '../../resource/svg/CloseSvg';
 
 interface ProductDialogProps {
   product: Product;
@@ -81,6 +82,7 @@ function ProductDialog(props: ProductDialogProps) {
   return (
     <Container>
       <ModalContainer>
+        <CloseSvg onClick={props.closeDialog} />
         <ProductImage src={props.product.imageUrl} />
         <AppLabel size={'large'}>{props.product.name}</AppLabel>
         <AppLabel size={'medium'}>{props.product.description}</AppLabel>

--- a/src/page/User/Order.tsx
+++ b/src/page/User/Order.tsx
@@ -3,13 +3,14 @@ import { useSearchParams } from 'react-router-dom';
 import styled from '@emotion/styled';
 import AppLabel from '../../component/common/label/AppLabel';
 import useWorkspace from '../../hook/useWorkspace';
-import { userWorkspaceAtom } from '../../recoil/atoms';
+import { orderBasketAtom, userWorkspaceAtom } from '../../recoil/atoms';
 import { useRecoilValue } from 'recoil';
 import AppBadge from '../../component/common/badge/AppBadge';
 import ProductCard from '../../component/product/ProductCard';
 import HorizontalDivider from '../../component/common/divider/HorizontalDivider';
 import { Product } from '../../type';
 import _ from 'lodash';
+import AppButton from '../../component/common/button/AppButton';
 
 const Container = styled.div`
   width: 100vw;
@@ -42,9 +43,20 @@ const CategoryBadges = styled.div`
   }
 `;
 
+const OrderButtonContainer = styled.div`
+  position: fixed;
+  bottom: 50px;
+  width: 100vw;
+  height: 50px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
 function Order() {
   const workspace = useRecoilValue(userWorkspaceAtom);
   const productsByCategory = _.groupBy<Product>(workspace.products, (product) => product.productCategory?.id);
+  const productsMap = _.keyBy(workspace.products, 'id');
   const categoryMap = _.keyBy(workspace.productCategories, 'id');
 
   const [searchParams] = useSearchParams();
@@ -52,6 +64,10 @@ function Order() {
   const tableNo = searchParams.get('tableNo');
 
   const { fetchWorkspace } = useWorkspace();
+  const orderBasket = useRecoilValue(orderBasketAtom);
+  const totalAmount = orderBasket.reduce((acc, cur) => {
+    return acc + productsMap[cur.productId].price * cur.quantity;
+  }, 0);
 
   useEffect(() => {
     fetchWorkspace(workspaceId);
@@ -83,6 +99,11 @@ function Order() {
           ))}
         </div>
       ))}
+      {totalAmount > 0 && (
+        <OrderButtonContainer>
+          <AppButton size={'medium'}>{totalAmount}원 주문하기</AppButton>
+        </OrderButtonContainer>
+      )}
     </Container>
   );
 }

--- a/src/recoil/atoms.ts
+++ b/src/recoil/atoms.ts
@@ -1,5 +1,5 @@
 import { atom } from 'recoil';
-import { Order, Product, Workspace } from '../type';
+import { Order, OrderProductBase, Product, Workspace } from '../type';
 
 export const ordersAtom = atom<Order[]>({
   key: 'ordersAtom',
@@ -35,4 +35,9 @@ export const userWorkspaceAtom = atom<Workspace>({
     createdAt: '',
     updatedAt: '',
   },
+});
+
+export const orderBasketAtom = atom<OrderProductBase[]>({
+  key: 'orderBasketAtom',
+  default: [],
 });

--- a/src/resource/svg/CloseSvg.tsx
+++ b/src/resource/svg/CloseSvg.tsx
@@ -1,0 +1,11 @@
+import * as React from 'react';
+
+interface CloseSvgProps extends React.SVGProps<SVGSVGElement> {}
+
+const CloseSvg = (props: CloseSvgProps) => (
+  <svg xmlns="http://www.w3.org/2000/svg" width={50} height={50} fill="none" viewBox="0 0 24 24" {...props}>
+    <script />
+    <path stroke="#000" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="m16 16-4-4m0 0L8 8m4 4 4-4m-4 4-4 4" />
+  </svg>
+);
+export default CloseSvg;

--- a/src/type/index.ts
+++ b/src/type/index.ts
@@ -10,9 +10,13 @@ export interface Order {
   updatedAt: string;
 }
 
-export interface OrderProduct {
-  product: Product;
+export interface OrderProductBase {
+  productId: number;
   quantity: number;
+}
+
+export interface OrderProduct extends OrderProductBase {
+  product: Product;
   isServed: boolean;
   totalPrice: number;
   id: number;


### PR DESCRIPTION
## 📚 개요

주문 페이지에서 상품을 선택하면 상품을 선택하여 장바구니에 추가할 수 있게 추가했습니다.
또한 해당 상품들의 총합을 구하여 주문 버튼도 보여주게 수정했습니다.

## 🕐 리뷰 예상 시간

> 15m

## ❗❗ 중요한 변경점(Option)

![image](https://github.com/Ji-InPark/KioSchool/assets/81283634/4376b289-d0cd-4f78-a23b-60de6164781a)
![image](https://github.com/Ji-InPark/KioSchool/assets/81283634/e7cbe12f-84fd-457a-9ab9-a00c1a8180df)

ProductDialog가 추가되었습니다.
또한 주문 버튼은 총합이 0원보다 많아야지 노출됩니다.