### PR TITLE
사용자의 계좌 정보 보여주는 기능

### DIFF
--- a/src/hooks/useAdminUser.tsx
+++ b/src/hooks/useAdminUser.tsx
@@ -2,11 +2,13 @@ import useApi from '@hooks/useApi';
 import { Workspace } from '@@types/index';
 import { useSetRecoilState } from 'recoil';
 import { adminUserAtom, workspacesAtom } from '@recoils/atoms';
+import { useNavigate } from 'react-router-dom';
 
 function useAdminUser() {
   const { adminApi } = useApi();
   const setWorkspaces = useSetRecoilState(workspacesAtom);
   const setAdminUser = useSetRecoilState(adminUserAtom);
+  const navigate = useNavigate();
 
   const isLoggedIn = () => {
     adminApi.get('/user');
@@ -46,7 +48,13 @@ function useAdminUser() {
   };
 
   const registerAccount = (account: string) => {
-    adminApi.post('/user/toss-account', { accountUrl: account }).catch((error) => console.error('Failed to add account: ', error));
+    adminApi
+      .post('/user/toss-account', { accountUrl: account })
+      .then(() => {
+        alert('계좌 정보가 성공적으로 저장되었습니다.');
+        navigate('/admin');
+      })
+      .catch((error) => console.error('Failed to add account: ', error));
   };
 
   return { isLoggedIn, fetchWorkspaces, createWorkspaces, leaveWorkspaces, registerAccount, fetchAdminUser };

--- a/src/hooks/useAdminUser.tsx
+++ b/src/hooks/useAdminUser.tsx
@@ -1,15 +1,23 @@
 import useApi from '@hooks/useApi';
 import { Workspace } from '@@types/index';
 import { useSetRecoilState } from 'recoil';
-import { workspacesAtom } from '@recoils/atoms';
+import { adminUserAtom, workspacesAtom } from '@recoils/atoms';
 
 function useAdminUser() {
   const { adminApi } = useApi();
   const setWorkspaces = useSetRecoilState(workspacesAtom);
+  const setAdminUser = useSetRecoilState(adminUserAtom);
 
   const isLoggedIn = () => {
     adminApi.get('/user');
     return true;
+  };
+
+  const fetchAdminUser = () => {
+    adminApi
+      .get('/user')
+      .then((res) => setAdminUser(res.data))
+      .catch((error) => console.error('Failed to fetch adminUser:', error));
   };
 
   const fetchWorkspaces = () => {
@@ -41,7 +49,7 @@ function useAdminUser() {
     adminApi.post('/user/toss-account', { accountUrl: account }).catch((error) => console.error('Failed to add account: ', error));
   };
 
-  return { isLoggedIn, fetchWorkspaces, createWorkspaces, leaveWorkspaces, registerAccount };
+  return { isLoggedIn, fetchWorkspaces, createWorkspaces, leaveWorkspaces, registerAccount, fetchAdminUser };
 }
 
 export default useAdminUser;

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -43,6 +43,7 @@ function AdminAccount() {
     decodedBank: '',
     accountNo: '',
   });
+  console.log('j');
 
   useEffect(() => {
     fetchAdminUser();
@@ -58,7 +59,7 @@ function AdminAccount() {
     const { decodedBank, accountNo } = accountInfo;
 
     dispatchAccount({ type: 'SET_ACCOUNT_INFO', payload: { decodedBank, accountNo } });
-  }, [adminUser.accountUrl]);
+  }, []);
 
   const onImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files?.length) {

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -23,6 +23,20 @@ const accountReducer = (state: AccountState, action: AccountAction): AccountStat
   }
 };
 
+const extractAccountInfo = (url: string): { decodedBank: string; accountNo: string } | null => {
+  const regex = /bank=([^&]+)&accountNo=([^&]+)/;
+  const match = url.match(regex);
+
+  if (match) {
+    const [, bank, accountNo] = match;
+    const decodedBank = decodeURIComponent(bank);
+
+    return { decodedBank, accountNo };
+  }
+
+  return null;
+};
+
 function AdminAccount() {
   const { registerAccount } = useAdminUser();
   const [fileURL, setFileURL] = useState<string>('');
@@ -33,20 +47,6 @@ function AdminAccount() {
   });
 
   useEffect(() => {
-    const extractAccountInfo = (url: string): { decodedBank: string; accountNo: string } | null => {
-      const regex = /bank=([^&]+)&accountNo=([^&]+)/;
-      const match = url.match(regex);
-
-      if (match) {
-        const [, bank, accountNo] = match;
-        const decodedBank = decodeURIComponent(bank);
-
-        return { decodedBank, accountNo };
-      }
-
-      return null;
-    };
-
     if (adminUser) {
       const accountInfo = extractAccountInfo(adminUser.accountUrl);
       if (accountInfo) {

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -24,7 +24,7 @@ const accountReducer = (state: AccountState, action: AccountAction): AccountStat
 };
 
 function AdminAccount() {
-  const { registerAccount, fetchAdminUser } = useAdminUser();
+  const { registerAccount } = useAdminUser();
   const [fileURL, setFileURL] = useState<string>('');
   const adminuser = useRecoilValue(adminUserAtom);
   const [accountState, dispatchAccount] = useReducer(accountReducer, {
@@ -108,7 +108,6 @@ function AdminAccount() {
       const decodedUrl: string = code.data;
       const url = removeAmountQuery(decodedUrl);
       registerAccount(url);
-      fetchAdminUser();
     };
   };
 

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -1,14 +1,36 @@
-import { ChangeEvent, useEffect, useState } from 'react';
+import { ChangeEvent, useEffect, useState, useReducer } from 'react';
 import jsQR from 'jsqr';
 import useAdminUser from '@hooks/useAdminUser';
 import uploadPreview from '@resources/image/uploadPreview.png';
 import { useRecoilValue } from 'recoil';
 import { adminUserAtom } from '@recoils/atoms';
 
+interface AccountState {
+  decodedBank: string;
+  accountNo: string;
+}
+
+type AccountAction = { type: 'SET_DECODED_BANK'; decodedBank: string } | { type: 'SET_ACCOUNT_NO'; accountNo: string };
+
+const accountReducer = (state: AccountState, action: AccountAction): AccountState => {
+  switch (action.type) {
+    case 'SET_DECODED_BANK':
+      return { ...state, decodedBank: action.decodedBank };
+    case 'SET_ACCOUNT_NO':
+      return { ...state, accountNo: action.accountNo };
+    default:
+      return state;
+  }
+};
+
 function AdminAccount() {
   const { registerAccount } = useAdminUser();
   const [fileURL, setFileURL] = useState<string>('');
   const adminuser = useRecoilValue(adminUserAtom);
+  const [accountState, dispatchAccount] = useReducer(accountReducer, {
+    decodedBank: '',
+    accountNo: '',
+  });
 
   useEffect(() => {
     const extractAccountInfo = (url: string): { decodedBank: string; accountNo: string } | null => {
@@ -24,8 +46,16 @@ function AdminAccount() {
 
       return null;
     };
-    extractAccountInfo(adminuser.accountUrl);
-  }, []);
+
+    if (adminuser) {
+      const accountInfo = extractAccountInfo(adminuser.accountUrl);
+      if (accountInfo) {
+        const { decodedBank, accountNo } = accountInfo;
+        dispatchAccount({ type: 'SET_DECODED_BANK', decodedBank });
+        dispatchAccount({ type: 'SET_ACCOUNT_NO', accountNo });
+      }
+    }
+  }, [adminuser]);
 
   const onImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files?.length) {
@@ -89,7 +119,11 @@ function AdminAccount() {
       <button type="button" onClick={removeImage}>
         제거 버튼
       </button>
-      {adminuser && <div>계좌 정보{adminuser.accountUrl}</div>}
+      {adminuser && (
+        <div>
+          계좌 정보 - 은행: {accountState.decodedBank}, 계좌번호: {accountState.accountNo}
+        </div>
+      )}
       <button onClick={submitHandler}>submit</button>
     </>
   );

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -24,7 +24,7 @@ const accountReducer = (state: AccountState, action: AccountAction): AccountStat
 };
 
 function AdminAccount() {
-  const { registerAccount } = useAdminUser();
+  const { registerAccount, fetchAdminUser } = useAdminUser();
   const [fileURL, setFileURL] = useState<string>('');
   const adminuser = useRecoilValue(adminUserAtom);
   const [accountState, dispatchAccount] = useReducer(accountReducer, {
@@ -108,6 +108,7 @@ function AdminAccount() {
       const decodedUrl: string = code.data;
       const url = removeAmountQuery(decodedUrl);
       registerAccount(url);
+      fetchAdminUser();
     };
   };
 

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -26,7 +26,7 @@ const accountReducer = (state: AccountState, action: AccountAction): AccountStat
 function AdminAccount() {
   const { registerAccount } = useAdminUser();
   const [fileURL, setFileURL] = useState<string>('');
-  const adminuser = useRecoilValue(adminUserAtom);
+  const adminUser = useRecoilValue(adminUserAtom);
   const [accountState, dispatchAccount] = useReducer(accountReducer, {
     decodedBank: '',
     accountNo: '',
@@ -47,15 +47,15 @@ function AdminAccount() {
       return null;
     };
 
-    if (adminuser) {
-      const accountInfo = extractAccountInfo(adminuser.accountUrl);
+    if (adminUser) {
+      const accountInfo = extractAccountInfo(adminUser.accountUrl);
       if (accountInfo) {
         const { decodedBank, accountNo } = accountInfo;
         dispatchAccount({ type: 'SET_DECODED_BANK', decodedBank });
         dispatchAccount({ type: 'SET_ACCOUNT_NO', accountNo });
       }
     }
-  }, [adminuser]);
+  }, [adminUser]);
 
   const onImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files?.length) {
@@ -119,9 +119,11 @@ function AdminAccount() {
       <button type="button" onClick={removeImage}>
         제거 버튼
       </button>
-      {adminuser && (
+      {adminUser && (
         <div>
-          계좌 정보 - 은행: {accountState.decodedBank}, 계좌번호: {accountState.accountNo}
+          은행: {accountState.decodedBank}
+          <br></br>
+          계좌번호: {accountState.accountNo}
         </div>
       )}
       <button onClick={submitHandler}>submit</button>

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -2,10 +2,13 @@ import { ChangeEvent, useState } from 'react';
 import jsQR from 'jsqr';
 import useAdminUser from '@hooks/useAdminUser';
 import uploadPreview from '@resources/image/uploadPreview.png';
+import { useRecoilValue } from 'recoil';
+import { adminUserAtom } from '@recoils/atoms';
 
 function AdminAccount() {
   const { registerAccount } = useAdminUser();
   const [fileURL, setFileURL] = useState<string>('');
+  const adminuser = useRecoilValue(adminUserAtom);
 
   const onImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files?.length) {
@@ -69,6 +72,7 @@ function AdminAccount() {
       <button type="button" onClick={removeImage}>
         제거 버튼
       </button>
+      {adminuser && <div>계좌 정보{adminuser.accountUrl}</div>}
       <button onClick={submitHandler}>submit</button>
     </>
   );

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -49,8 +49,10 @@ function AdminAccount() {
 
   useEffect(() => {
     fetchAdminUser();
+  }, []);
 
-    if (!adminUser) return;
+  useEffect(() => {
+    if (!adminUser || adminUser.accountUrl == '') return;
 
     const accountInfo = extractAccountInfo(adminUser.accountUrl);
 
@@ -59,7 +61,7 @@ function AdminAccount() {
     const { decodedBank, accountNo } = accountInfo;
     dispatchAccount({ type: 'SET_DECODED_BANK', decodedBank });
     dispatchAccount({ type: 'SET_ACCOUNT_NO', accountNo });
-  }, []);
+  }, [adminUser.accountUrl]);
 
   const onImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files?.length) {

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -43,7 +43,6 @@ function AdminAccount() {
     decodedBank: '',
     accountNo: '',
   });
-  console.log(accountState.decodedBank);
 
   useEffect(() => {
     fetchAdminUser();

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -29,15 +29,13 @@ const extractAccountInfo = (url: string): { decodedBank: string; accountNo: stri
   const bankMatch = url.match(bankRegex);
   const accountNoMatch = url.match(accountNoRegex);
 
-  if (bankMatch && accountNoMatch) {
-    const [, bank] = bankMatch;
-    const [, accountNo] = accountNoMatch;
-    const decodedBank = decodeURIComponent(bank);
+  if (!bankMatch || !accountNoMatch) return null;
 
-    return { decodedBank, accountNo };
-  }
+  const [, bank] = bankMatch;
+  const [, accountNo] = accountNoMatch;
+  const decodedBank = decodeURIComponent(bank);
 
-  return null;
+  return { decodedBank, accountNo };
 };
 
 function AdminAccount() {
@@ -51,14 +49,16 @@ function AdminAccount() {
 
   useEffect(() => {
     fetchAdminUser();
-    if (adminUser) {
-      const accountInfo = extractAccountInfo(adminUser.accountUrl);
-      if (accountInfo) {
-        const { decodedBank, accountNo } = accountInfo;
-        dispatchAccount({ type: 'SET_DECODED_BANK', decodedBank });
-        dispatchAccount({ type: 'SET_ACCOUNT_NO', accountNo });
-      }
-    }
+
+    if (!adminUser) return;
+
+    const accountInfo = extractAccountInfo(adminUser.accountUrl);
+
+    if (!accountInfo) return;
+
+    const { decodedBank, accountNo } = accountInfo;
+    dispatchAccount({ type: 'SET_DECODED_BANK', decodedBank });
+    dispatchAccount({ type: 'SET_ACCOUNT_NO', accountNo });
   }, []);
 
   const onImageChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -41,7 +41,7 @@ const extractAccountInfo = (url: string): { decodedBank: string; accountNo: stri
 };
 
 function AdminAccount() {
-  const { registerAccount } = useAdminUser();
+  const { registerAccount, fetchAdminUser } = useAdminUser();
   const [fileURL, setFileURL] = useState<string>('');
   const adminUser = useRecoilValue(adminUserAtom);
   const [accountState, dispatchAccount] = useReducer(accountReducer, {
@@ -50,6 +50,7 @@ function AdminAccount() {
   });
 
   useEffect(() => {
+    fetchAdminUser();
     if (adminUser) {
       const accountInfo = extractAccountInfo(adminUser.accountUrl);
       if (accountInfo) {
@@ -58,7 +59,7 @@ function AdminAccount() {
         dispatchAccount({ type: 'SET_ACCOUNT_NO', accountNo });
       }
     }
-  }, [adminUser]);
+  }, []);
 
   const onImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files?.length) {

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -115,7 +115,7 @@ function AdminAccount() {
   return (
     <>
       <div>ADD ACCOUNT</div>
-      <img src={fileURL || uploadPreview} alt={fileURL} />
+      <img src={fileURL || uploadPreview} alt={fileURL} style={{ width: '300px', height: '300px' }} />
       <input type="file" id="img" accept="image/*" onChange={onImageChange} />
       <button type="button" onClick={removeImage}>
         제거 버튼

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -58,7 +58,7 @@ function AdminAccount() {
     const { decodedBank, accountNo } = accountInfo;
 
     dispatchAccount({ type: 'SET_ACCOUNT_INFO', payload: { decodedBank, accountNo } });
-  }, []);
+  }, [adminUser.accountUrl]);
 
   const onImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files?.length) {

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import jsQR from 'jsqr';
 import useAdminUser from '@hooks/useAdminUser';
 import uploadPreview from '@resources/image/uploadPreview.png';
@@ -9,6 +9,23 @@ function AdminAccount() {
   const { registerAccount } = useAdminUser();
   const [fileURL, setFileURL] = useState<string>('');
   const adminuser = useRecoilValue(adminUserAtom);
+
+  useEffect(() => {
+    const extractAccountInfo = (url: string): { decodedBank: string; accountNo: string } | null => {
+      const regex = /bank=([^&]+)&accountNo=([^&]+)/;
+      const match = url.match(regex);
+
+      if (match) {
+        const [, bank, accountNo] = match;
+        const decodedBank = decodeURIComponent(bank);
+
+        return { decodedBank, accountNo };
+      }
+
+      return null;
+    };
+    extractAccountInfo(adminuser.accountUrl);
+  }, []);
 
   const onImageChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!event.target.files?.length) {

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -24,11 +24,14 @@ const accountReducer = (state: AccountState, action: AccountAction): AccountStat
 };
 
 const extractAccountInfo = (url: string): { decodedBank: string; accountNo: string } | null => {
-  const regex = /bank=([^&]+)&accountNo=([^&]+)/;
-  const match = url.match(regex);
+  const bankRegex = /bank=([^&]+)/;
+  const accountNoRegex = /accountNo=([^&]+)/;
+  const bankMatch = url.match(bankRegex);
+  const accountNoMatch = url.match(accountNoRegex);
 
-  if (match) {
-    const [, bank, accountNo] = match;
+  if (bankMatch && accountNoMatch) {
+    const [, bank] = bankMatch;
+    const [, accountNo] = accountNoMatch;
     const decodedBank = decodeURIComponent(bank);
 
     return { decodedBank, accountNo };

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -10,14 +10,12 @@ interface AccountState {
   accountNo: string;
 }
 
-type AccountAction = { type: 'SET_DECODED_BANK'; decodedBank: string } | { type: 'SET_ACCOUNT_NO'; accountNo: string };
+type AccountAction = { type: 'SET_ACCOUNT_INFO'; payload: { decodedBank: string; accountNo: string } };
 
 const accountReducer = (state: AccountState, action: AccountAction): AccountState => {
   switch (action.type) {
-    case 'SET_DECODED_BANK':
-      return { ...state, decodedBank: action.decodedBank };
-    case 'SET_ACCOUNT_NO':
-      return { ...state, accountNo: action.accountNo };
+    case 'SET_ACCOUNT_INFO':
+      return { ...state, decodedBank: action.payload.decodedBank, accountNo: action.payload.accountNo };
     default:
       return state;
   }
@@ -37,7 +35,6 @@ const extractAccountInfo = (url: string): { decodedBank: string; accountNo: stri
 
   return { decodedBank, accountNo };
 };
-
 function AdminAccount() {
   const { registerAccount, fetchAdminUser } = useAdminUser();
   const [fileURL, setFileURL] = useState<string>('');
@@ -46,21 +43,22 @@ function AdminAccount() {
     decodedBank: '',
     accountNo: '',
   });
+  console.log(accountState.decodedBank);
 
   useEffect(() => {
     fetchAdminUser();
   }, []);
 
   useEffect(() => {
-    if (!adminUser || adminUser.accountUrl == '') return;
+    if (!adminUser || !adminUser.accountUrl) return;
 
     const accountInfo = extractAccountInfo(adminUser.accountUrl);
 
     if (!accountInfo) return;
 
     const { decodedBank, accountNo } = accountInfo;
-    dispatchAccount({ type: 'SET_DECODED_BANK', decodedBank });
-    dispatchAccount({ type: 'SET_ACCOUNT_NO', accountNo });
+
+    dispatchAccount({ type: 'SET_ACCOUNT_INFO', payload: { decodedBank, accountNo } });
   }, [adminUser.accountUrl]);
 
   const onImageChange = (event: ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/Admin/AdminAccount.tsx
+++ b/src/pages/Admin/AdminAccount.tsx
@@ -43,7 +43,6 @@ function AdminAccount() {
     decodedBank: '',
     accountNo: '',
   });
-  console.log('j');
 
   useEffect(() => {
     fetchAdminUser();

--- a/src/pages/Admin/AdminHome.tsx
+++ b/src/pages/Admin/AdminHome.tsx
@@ -6,14 +6,13 @@ import useCustomNavigate from '@hooks/useCustomNavigate';
 import { Link } from 'react-router-dom';
 
 function AdminHome() {
-  const { fetchWorkspaces, createWorkspaces, leaveWorkspaces, fetchAdminUser } = useAdminUser();
+  const { fetchWorkspaces, createWorkspaces, leaveWorkspaces } = useAdminUser();
   const { appendPath } = useCustomNavigate();
   const userInputRef = useRef<HTMLInputElement>(null);
   const workspaces = useRecoilValue(workspacesAtom);
 
   useEffect(() => {
     fetchWorkspaces();
-    fetchAdminUser();
   }, []);
 
   const createHandler = (e: React.FormEvent) => {

--- a/src/pages/Admin/AdminHome.tsx
+++ b/src/pages/Admin/AdminHome.tsx
@@ -6,13 +6,14 @@ import useCustomNavigate from '@hooks/useCustomNavigate';
 import { Link } from 'react-router-dom';
 
 function AdminHome() {
-  const { fetchWorkspaces, createWorkspaces, leaveWorkspaces } = useAdminUser();
+  const { fetchWorkspaces, createWorkspaces, leaveWorkspaces, fetchAdminUser } = useAdminUser();
   const { appendPath } = useCustomNavigate();
   const userInputRef = useRef<HTMLInputElement>(null);
   const workspaces = useRecoilValue(workspacesAtom);
 
   useEffect(() => {
     fetchWorkspaces();
+    fetchAdminUser();
   }, []);
 
   const createHandler = (e: React.FormEvent) => {

--- a/src/recoils/atoms.ts
+++ b/src/recoils/atoms.ts
@@ -1,5 +1,5 @@
 import { atom } from 'recoil';
-import { Order, OrderProductBase, Product, Workspace } from '@@types/index';
+import { Order, OrderProductBase, Product, User, Workspace } from '@@types/index';
 
 export const ordersAtom = atom<Order[]>({
   key: 'ordersAtom',
@@ -31,6 +31,19 @@ export const userWorkspaceAtom = atom<Workspace>({
     },
     products: [],
     productCategories: [],
+    id: 0,
+    createdAt: '',
+    updatedAt: '',
+  },
+});
+
+export const adminUserAtom = atom<User>({
+  key: 'adminUserAtom',
+  default: {
+    name: '',
+    email: '',
+    role: '',
+    accountUrl: '',
     id: 0,
     createdAt: '',
     updatedAt: '',


### PR DESCRIPTION
## 📚 개요

> 사용자의 등록된 계좌 정보를 보여줍니다.

## 🕐 리뷰 예상 시간

> 5m

## ❗❗ 중요한 변경점(Option)

> 
계좌 정보를 useReducer를 통해 상태 관리합니다. 
사용자의 정보를 담는 adminUserAtom을 만들었습니다.
recoil을 통해 사용자 계좌정보를 가져오기 때문에 새로고침을 하게 되면 계좌정보가 NULL로 초기화 되는 문제가 있습니다.