### PR TITLE
REMOVE - 결제 주문 페이지에서 계좌 정보 삭제

### DIFF
--- a/src/pages/User/order/OrderPay.tsx
+++ b/src/pages/User/order/OrderPay.tsx
@@ -59,8 +59,6 @@ function OrderPay() {
   const tableNo = searchParams.get('tableNo');
 
   const tossAccountUrl = workspace.owner.accountUrl;
-  const accountName = /bank=(.*?)&/g.exec(tossAccountUrl)?.[1] || 'test';
-  const accountNumber = /accountNo=(.*?)&/g.exec(tossAccountUrl)?.[1] || 'test';
 
   return (
     <Container>
@@ -69,9 +67,6 @@ function OrderPay() {
         <AppBadge>{totalAmount.toLocaleString()}원</AppBadge>
       </Header>
       <AppInputWithLabel titleLabel={'입금자명'} style={{ width: '80%' }} placeholder={'입금자명을 입력해주세요.'} ref={customerNameRef} />
-      <AppLabel>{decodeURI(accountName)}</AppLabel>
-      <br />
-      <AppLabel>{accountNumber}</AppLabel>
       <OrderButton
         amount={totalAmount}
         buttonLabel={`Toss로 결제하기`}


### PR DESCRIPTION
## 📚 개요

ux를 생각해봤을 때 계좌 정보를 복사하는 과정이 오히려 헷갈릴 가능성이 높다고 생각해서 계좌 정보를 볼 수 없게 삭제했습니다.
(계좌 정보 복사 버튼을 누르자마자 주문이 들어가야하는데 헷갈려서 여러번 누르면 주문이 여러번 들어간다던가 하는 문제가 생길 수 있음)

## 🕐 리뷰 예상 시간

> 1m

## ❗❗ 중요한 변경점(Option)

<img width="443" alt="image" src="https://github.com/Ji-InPark/KioSchool/assets/81283634/c2417ff8-18e3-4714-9e40-a483fc65ca34">
